### PR TITLE
Fix empty initial value - Offer optional value prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,13 @@ Changes:
 - introduces optional `clearOnClickInput` prop (default false)
 - introduces optional `onClick` lifecycle method prop (default empty function)
 
+#### Version 2.0.0
+
+Changes:
+
+- refactors component to functional component using hooks
+- adds `useStateRef` to reduce re-renders and boost performance
+
 ## Installation
 
 ### Installation via npm
@@ -116,6 +123,7 @@ const YourComponent = ({ myValues }) => {
 | [debounceTime](#markdown-header-debounceTime)               | number   | optional          | 0                          |
 | [debounceLoader](#markdown-header-debounceLoader)           | string   | optional          | 'Loading...'               |
 | [onInput](#markdown-header-onInput)                         | function | optional          | -                          |
+| [onClick](#markdown-header-onClick)                         | function | optional          | -                          |
 
 ### <a name="markdown-header-items"></a>items
 
@@ -291,4 +299,4 @@ useEffect(() => {
 
 - The callback function that will be called whenever the user clicks the input field
 - This callback is exposed so you can implement `clearOnClickInput` on your own if you pass the `value` prop
-- The callback will receive the `currentInput` of type string based on `clearOnClickInput` and the last user input.
+- The callback will receive the `currentInput` of type string based on `clearOnClickInput` and the last user input

--- a/index.d.ts
+++ b/index.d.ts
@@ -18,14 +18,16 @@ declare module 'react-datalist-input' {
         dropdownClassName?: string;
         requiredInputLength?: number;
         clearInputOnSelect?: boolean;
+        clearInputOnClick?: boolean;
         suppressReselect?: boolean;
         dropDownLength?: number;
-        initialValue?: string;
+        value?: string;
         onDropdownOpen?: () => void;
         onDropdownClose?: () => void;
         debounceTime?: number;
         debounceLoader?: React.ReactNode;
         onInput?: (inputValue: string) => void;
+        onClick?: (inputValue: string) => void;
     }
 
     export default class DataListInput extends React.Component<DataListInputProperties> {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-datalist-input",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "This package provides a react component as follows: an input field with a drop down menu to pick a possible option based on the current input.",
   "main": "./dist/DataListInput.js",
   "files": [

--- a/src/DataListInput.jsx
+++ b/src/DataListInput.jsx
@@ -42,11 +42,12 @@ const indexOfItem = (item, items) =>
 const DataListInput = ({
   activeItemClassName,
   clearInputOnSelect,
+  clearInputOnClick,
   debounceLoader,
   debounceTime,
   dropdownClassName,
   dropDownLength,
-  initialValue,
+  value,
   inputClassName,
   itemClassName,
   match,
@@ -54,6 +55,7 @@ const DataListInput = ({
   onDropdownOpen,
   onInput,
   onSelect,
+  onClick,
   placeholder,
   requiredInputLength,
   suppressReselect,
@@ -63,7 +65,7 @@ const DataListInput = ({
   const [lastValidItem, setLastValidItem] = useState();
   /* current input text */
   const [currentInput, setCurrentInput, currentInputRef] = useStateRef(
-    initialValue
+    value !== undefined ? value : ''
   );
   /* current set of matching items */
   const [matchingItems, setMatchingItems] = useState([]);
@@ -113,18 +115,22 @@ const DataListInput = ({
   }, [onDropdownClose, setVisible, visibleRef]);
 
   useEffect(() => {
-    // if we have an initialValue, we want to reset it everytime we update and are empty
-    // also setting a new initialValue will trigger this
-    if (!currentInput && initialValue && !visible && !isMatchingDebounced) {
-      setCurrentInput(initialValue);
+    // the parent component can pass its own value prop that will override the internally used currentInput
+    // this will happen only after we are have finished the current computing step and the dropdown is invisible
+    // (to avoid confusion of changing input values for the user)
+    /*
+     * we have to distinguish undefined and empty string value
+     * value == undefined => not set, use internal current input
+     * value !== undefined => value set, use value and override currentInput
+     * this enables value === '' to clear the input field
+     */
+    const isValuePropSet = value !== undefined;
+    const isValueDifferent = currentInputRef.current !== value;
+    const isMatchingRunning = visible || isMatchingDebounced;
+    if (isValuePropSet && isValueDifferent && !isMatchingRunning) {
+      setCurrentInput(value);
     }
-  }, [
-    currentInput,
-    visible,
-    isMatchingDebounced,
-    initialValue,
-    setCurrentInput,
-  ]);
+  }, [visible, isMatchingDebounced, value, setCurrentInput, currentInputRef]);
 
   /**
    * runs the matching process of the current input
@@ -206,32 +212,33 @@ const DataListInput = ({
 
   /**
    * gets called when someone starts to write in the input field
-   * @param value
+   * @param event
    */
   const onHandleInput = useCallback(
     event => {
-      const { value } = event.target;
-      debouncedMatchingUpdateStep(value);
-      onInput(value);
+      const { value: newValue } = event.target;
+      debouncedMatchingUpdateStep(newValue);
+      onInput(newValue);
     },
     [debouncedMatchingUpdateStep, onInput]
   );
 
   const onClickInput = useCallback(() => {
-    let value = currentInputRef.current;
-    // if user clicks on input field with initialValue,
+    let currentValue = currentInputRef.current;
+    // if user clicks on input field with value,
     // the user most likely wants to clear the input field
-    if (initialValue && value === initialValue) {
-      value = '';
+    if (currentValue && clearInputOnClick) {
+      currentValue = '';
     }
-
-    const reachedRequiredLength = value.length >= requiredInputLength;
+    onClick(currentValue);
+    const reachedRequiredLength = currentValue.length >= requiredInputLength;
     if (reachedRequiredLength && !visibleRef.current) {
-      debouncedMatchingUpdateStep(value);
+      debouncedMatchingUpdateStep(currentValue);
     }
   }, [
     currentInputRef,
-    initialValue,
+    clearInputOnClick,
+    onClick,
     requiredInputLength,
     visibleRef,
     debouncedMatchingUpdateStep,
@@ -448,12 +455,14 @@ DataListInput.propTypes = {
   activeItemClassName: PropTypes.string,
   requiredInputLength: PropTypes.number,
   clearInputOnSelect: PropTypes.bool,
+  clearInputOnClick: PropTypes.bool,
   suppressReselect: PropTypes.bool,
   dropDownLength: PropTypes.number,
-  initialValue: PropTypes.string,
+  value: PropTypes.string,
   debounceTime: PropTypes.number,
   debounceLoader: PropTypes.node,
   onInput: PropTypes.func,
+  onClick: PropTypes.func,
 };
 
 DataListInput.defaultProps = {
@@ -465,14 +474,16 @@ DataListInput.defaultProps = {
   activeItemClassName: '',
   requiredInputLength: 0,
   clearInputOnSelect: false,
+  clearInputOnClick: false,
   suppressReselect: true,
   dropDownLength: Infinity,
-  initialValue: '',
+  value: undefined,
   debounceTime: 0,
   debounceLoader: undefined,
   onDropdownOpen: () => {},
   onDropdownClose: () => {},
   onInput: () => {},
+  onClick: () => {},
 };
 
 export default DataListInput;

--- a/tests/demo-app/.vscode/launch.json
+++ b/tests/demo-app/.vscode/launch.json
@@ -1,0 +1,31 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "node",
+            "name": "vscode-jest-tests",
+            "request": "launch",
+            "args": [
+                "--runInBand"
+            ],
+            "cwd": "${workspaceFolder}",
+            "console": "integratedTerminal",
+            "internalConsoleOptions": "neverOpen",
+            "disableOptimisticBPs": true,
+            "program": "${workspaceFolder}/node_modules/jest/bin/jest"
+        },
+        {
+            "name": "Chrome",
+            "type": "chrome",
+            "request": "launch",
+            "url": "http://localhost:3000",
+            "webRoot": "${workspaceFolder}/src",
+            "sourceMapPathOverrides": {
+              "webpack:///src/*": "${webRoot}/*"
+            }
+        }
+    ]
+}

--- a/tests/demo-app/package-lock.json
+++ b/tests/demo-app/package-lock.json
@@ -1631,21 +1631,36 @@
       "integrity": "sha512-4diPfzWbLEIElVG4AnqP+00SULlPzNuyJFNnmMrLgyaxG6tZXJ1sn7mjBu4fHrJE+Yp/jgylOweJn2xsLMFggQ=="
     },
     "adjust-sourcemap-loader": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/adjust-sourcemap-loader/-/adjust-sourcemap-loader-2.0.0.tgz",
-      "integrity": "sha512-4hFsTsn58+YjrU9qKzML2JSSDqKvN8mUGQ0nNIrfPi8hmIONT4L3uUaT6MKdMsZ9AjsU6D2xDkZxCkbQPxChrA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/adjust-sourcemap-loader/-/adjust-sourcemap-loader-3.0.0.tgz",
+      "integrity": "sha512-YBrGyT2/uVQ/c6Rr+t6ZJXniY03YtHGMJQYal368burRGYKqhx9qGTWqcBU5s1CwYY9E/ri63RYyG1IacMZtqw==",
       "requires": {
-        "assert": "1.4.1",
-        "camelcase": "5.0.0",
-        "loader-utils": "1.2.3",
-        "object-path": "0.11.4",
-        "regex-parser": "2.2.10"
+        "loader-utils": "^2.0.0",
+        "regex-parser": "^2.2.11"
       },
       "dependencies": {
-        "camelcase": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.0.0.tgz",
-          "integrity": "sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA=="
+        "emojis-list": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
+          "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q=="
+        },
+        "json5": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
+          "integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
+          "requires": {
+            "minimist": "^1.2.5"
+          }
+        },
+        "loader-utils": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
+          "integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
+          "requires": {
+            "big.js": "^5.2.2",
+            "emojis-list": "^3.0.0",
+            "json5": "^2.1.2"
+          }
         }
       }
     },
@@ -4528,13 +4543,13 @@
       }
     },
     "es5-ext": {
-      "version": "0.10.50",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.50.tgz",
-      "integrity": "sha512-KMzZTPBkeQV/JcSQhI5/z6d9VWJ3EnQ194USTUwIYZ2ZbpN8+SGXQKt1h68EX44+qt+Fzr8DO17vnxrw7c3agw==",
+      "version": "0.10.53",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
+      "integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
       "requires": {
         "es6-iterator": "~2.0.3",
-        "es6-symbol": "~3.1.1",
-        "next-tick": "^1.0.0"
+        "es6-symbol": "~3.1.3",
+        "next-tick": "~1.0.0"
       }
     },
     "es6-iterator": {
@@ -4548,12 +4563,12 @@
       }
     },
     "es6-symbol": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
-      "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
+      "integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
       "requires": {
-        "d": "1",
-        "es5-ext": "~0.10.14"
+        "d": "^1.0.1",
+        "ext": "^1.1.2"
       }
     },
     "escape-html": {
@@ -5548,6 +5563,21 @@
           "version": "6.7.0",
           "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
           "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
+        }
+      }
+    },
+    "ext": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/ext/-/ext-1.4.0.tgz",
+      "integrity": "sha512-Key5NIsUxdqKg3vIsdw9dSuXpPCQ297y6wBjL30edxwPgt2E44WcWBZey/ZvUc6sERLTxKdyCu4gZFmUbk1Q7A==",
+      "requires": {
+        "type": "^2.0.0"
+      },
+      "dependencies": {
+        "type": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/type/-/type-2.1.0.tgz",
+          "integrity": "sha512-G9absDWvhAWCV2gmF1zKud3OyC61nZDwWvBL2DApaVFogI07CprggiQAOOjvp2NRjYWFzPyu7vwtDrQFq8jeSA=="
         }
       }
     },
@@ -9285,11 +9315,6 @@
         "lower-case": "^1.1.1"
       }
     },
-    "node-forge": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.9.0.tgz",
-      "integrity": "sha512-7ASaDa3pD+lJ3WvXFsxekJQelBKRpne+GOVbLbtHYdd7pFspyeuJHnWfLplGf3SwKGbfs/aYl5V/JCIaHVUKKQ=="
-    },
     "node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -9528,11 +9553,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
-    },
-    "object-path": {
-      "version": "0.11.4",
-      "resolved": "https://registry.npmjs.org/object-path/-/object-path-0.11.4.tgz",
-      "integrity": "sha1-NwrnUvvzfePqcKhhwju6iRVpGUk="
     },
     "object-visit": {
       "version": "1.0.1",
@@ -11440,9 +11460,9 @@
       }
     },
     "regex-parser": {
-      "version": "2.2.10",
-      "resolved": "https://registry.npmjs.org/regex-parser/-/regex-parser-2.2.10.tgz",
-      "integrity": "sha512-8t6074A68gHfU8Neftl0Le6KTDwfGAj7IyjPIMSfikI2wJUTHDMaIq42bUsfVnj8mhx0R+45rdUXHGpN164avA=="
+      "version": "2.2.11",
+      "resolved": "https://registry.npmjs.org/regex-parser/-/regex-parser-2.2.11.tgz",
+      "integrity": "sha512-jbD/FT0+9MBU2XAZluI7w2OBs1RBi6p9M83nkoZayQXXU9e8Robt69FcZc7wU4eJD/YFTjn1JdCk3rbMJajz8Q=="
     },
     "regexp-tree": {
       "version": "0.1.11",
@@ -11714,31 +11734,34 @@
       "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
     },
     "resolve-url-loader": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/resolve-url-loader/-/resolve-url-loader-3.1.0.tgz",
-      "integrity": "sha512-2QcrA+2QgVqsMJ1Hn5NnJXIGCX1clQ1F6QJTqOeiaDw9ACo1G2k+8/shq3mtqne03HOFyskAClqfxKyFBriXZg==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/resolve-url-loader/-/resolve-url-loader-3.1.2.tgz",
+      "integrity": "sha512-QEb4A76c8Mi7I3xNKXlRKQSlLBwjUV/ULFMP+G7n3/7tJZ8MG5wsZ3ucxP1Jz8Vevn6fnJsxDx9cIls+utGzPQ==",
       "requires": {
-        "adjust-sourcemap-loader": "2.0.0",
-        "camelcase": "5.0.0",
+        "adjust-sourcemap-loader": "3.0.0",
+        "camelcase": "5.3.1",
         "compose-function": "3.0.3",
-        "convert-source-map": "1.6.0",
+        "convert-source-map": "1.7.0",
         "es6-iterator": "2.0.3",
         "loader-utils": "1.2.3",
-        "postcss": "7.0.14",
+        "postcss": "7.0.21",
         "rework": "1.0.1",
         "rework-visit": "1.0.0",
         "source-map": "0.6.1"
       },
       "dependencies": {
-        "camelcase": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.0.0.tgz",
-          "integrity": "sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA=="
+        "convert-source-map": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
+          "integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
+          "requires": {
+            "safe-buffer": "~5.1.1"
+          }
         },
         "postcss": {
-          "version": "7.0.14",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
-          "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
+          "version": "7.0.21",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.21.tgz",
+          "integrity": "sha512-uIFtJElxJo29QC753JzhidoAhvp/e/Exezkdhfmt8AymWT6/5B7W1WmponYWkHk2eg6sONyTch0A3nkMPun3SQ==",
           "requires": {
             "chalk": "^2.4.2",
             "source-map": "^0.6.1",
@@ -11976,11 +11999,18 @@
       "integrity": "sha1-Yl2GWPhlr0Psliv8N2o3NZpJlMo="
     },
     "selfsigned": {
-      "version": "1.10.7",
-      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.7.tgz",
-      "integrity": "sha512-8M3wBCzeWIJnQfl43IKwOmC4H/RAp50S8DF60znzjW5GVqTcSe2vWclt7hmYVPkKPlHWOu5EaWOMZ2Y6W8ZXTA==",
+      "version": "1.10.8",
+      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.8.tgz",
+      "integrity": "sha512-2P4PtieJeEwVgTU9QEcwIRDQ/mXJLX8/+I3ur+Pg16nS8oNbrGxEso9NyYWy8NAmXiNl4dlAp5MwoNeCWzON4w==",
       "requires": {
-        "node-forge": "0.9.0"
+        "node-forge": "^0.10.0"
+      },
+      "dependencies": {
+        "node-forge": {
+          "version": "0.10.0",
+          "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
+          "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA=="
+        }
       }
     },
     "semver": {
@@ -13370,9 +13400,9 @@
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
     },
     "type": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/type/-/type-1.0.3.tgz",
-      "integrity": "sha512-51IMtNfVcee8+9GJvj0spSuFcZHe9vSib6Xtgsny1Km9ugyz2mbS08I3rsUIRYgJohFRFU1160sgRodYz378Hg=="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
+      "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg=="
     },
     "type-check": {
       "version": "0.3.2",

--- a/tests/demo-app/package.json
+++ b/tests/demo-app/package.json
@@ -41,7 +41,7 @@
     "react-dev-utils": "^9.0.3",
     "react-dom": "^16.9.0",
     "resolve": "1.12.0",
-    "resolve-url-loader": "3.1.0",
+    "resolve-url-loader": "^3.1.2",
     "sass-loader": "7.2.0",
     "semver": "6.3.0",
     "style-loader": "1.0.0",

--- a/tests/demo-app/src/App.js
+++ b/tests/demo-app/src/App.js
@@ -78,6 +78,9 @@ function App() {
   return (
     <div className="App">
       <div className="content">
+        <button onClick={() => setItem(undefined)} type="button">
+          Clear
+        </button>
         {item && <div>{`Current Item: ${item.label}`}</div>}
         <div className="wrapper">
           <DataListInput
@@ -85,10 +88,11 @@ function App() {
             onSelect={i => setItem(i)}
             placeholder="Select a ingredient"
             clearInputOnSelect={false}
+            clearInputOnClick={false}
             suppressReselect
-            initialValue={item ? item.label : ''}
             debounceTime={1000}
-            debounceLoader={<>Hello</>}
+            debounceLoader={<>Loading...</>}
+            value={item ? item.label : ''}
           />
         </div>
       </div>

--- a/tests/unit/DataListInput.test.js
+++ b/tests/unit/DataListInput.test.js
@@ -8,7 +8,6 @@ import {
   queryAllByRole,
 } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
-import { doc } from 'prettier';
 import DataListInput from '../../src/DataListInput';
 
 const defaultProps = {
@@ -20,14 +19,16 @@ const defaultProps = {
   activeItemClassName: '',
   requiredInputLength: 0,
   clearInputOnSelect: false,
+  clearInputOnClick: false,
   suppressReselect: true,
   dropDownLength: Infinity,
-  initialValue: '',
+  value: undefined,
   debounceTime: 0,
   debounceLoader: undefined,
   onDropdownOpen: () => {},
   onDropdownClose: () => {},
   onInput: () => {},
+  onClick: () => {},
 };
 const data = [
   {
@@ -78,6 +79,7 @@ const handleSelect = jest.fn();
 const onDropdownOpen = jest.fn();
 const onDropdownClose = jest.fn();
 const onInput = jest.fn();
+const onClick = jest.fn();
 
 describe('DataListInput', () => {
   afterEach(() => {
@@ -87,7 +89,7 @@ describe('DataListInput', () => {
   test('renders without errors and sets default props correctly', () => {
     render(<DataListInput items={data} onSelect={handleSelect} />);
     const datalistInput = screen.getByRole('textbox');
-    expect(datalistInput).toHaveTextContent(defaultProps.initialValue);
+    expect(datalistInput).toHaveTextContent('');
     expect(datalistInput).toHaveAttribute(
       'placeholder',
       defaultProps.placeholder
@@ -164,19 +166,87 @@ describe('DataListInput', () => {
     expect(matchingItems.length).toBe(2);
   });
 
-  test('renders matching items with initialValue', async () => {
+  test('clearInputOnClick: renders matching items with value', async () => {
     render(
       <DataListInput
         items={data}
         placeholder={placeholder}
         onSelect={handleSelect}
-        initialValue="Pea"
+        value="Pea"
+      />
+    );
+    const datalistInput = screen.getByRole('textbox');
+    fireEvent.click(datalistInput);
+    const items = await screen.getAllByRole('button');
+    expect(items.length).toBe(2);
+  });
+
+  test('clearInputOnClick: renders matching items without value', async () => {
+    render(
+      <DataListInput
+        items={data}
+        placeholder={placeholder}
+        onSelect={handleSelect}
+        value="Pea"
+        clearInputOnClick
       />
     );
     const datalistInput = screen.getByRole('textbox');
     fireEvent.click(datalistInput);
     const items = await screen.getAllByRole('button');
     expect(items.length).toBe(data.length);
+  });
+
+  test('clearInputOnSelect: removes value if set', async () => {
+    render(
+      <DataListInput
+        items={data}
+        placeholder={placeholder}
+        onSelect={handleSelect}
+        clearInputOnSelect
+      />
+    );
+    const datalistInput = screen.getByRole('textbox');
+    fireEvent.click(datalistInput);
+    fireEvent.change(datalistInput, { target: { value: 'Apple' } });
+    const appleItem = await screen.getByRole('button');
+    fireEvent.click(appleItem);
+    expect(datalistInput).toHaveAttribute('value', '');
+  });
+
+  test('clearInputOnSelect: keeps value if false', async () => {
+    render(
+      <DataListInput
+        items={data}
+        placeholder={placeholder}
+        onSelect={handleSelect}
+        value="Apple"
+        clearInputOnSelect={false} // default value
+      />
+    );
+    const datalistInput = screen.getByRole('textbox');
+    fireEvent.click(datalistInput);
+    fireEvent.change(datalistInput, { target: { value: 'Apple' } });
+    const appleItem = await screen.getByRole('button');
+    fireEvent.click(appleItem);
+    expect(datalistInput).toHaveAttribute('value', 'Apple');
+  });
+
+  test('clearInputOnSelect: clear input on select does not work if value is set', async () => {
+    render(
+      <DataListInput
+        items={data}
+        placeholder={placeholder}
+        onSelect={handleSelect}
+        value="Apple"
+        clearInputOnSelect
+      />
+    );
+    const datalistInput = screen.getByRole('textbox');
+    fireEvent.click(datalistInput);
+    const appleItem = await screen.getByRole('button');
+    fireEvent.click(appleItem);
+    expect(datalistInput).toHaveAttribute('value', 'Apple');
   });
 
   test('renders matching items with custom matching func', async () => {
@@ -206,12 +276,14 @@ describe('DataListInput', () => {
         onDropdownOpen={onDropdownOpen}
         onDropdownClose={onDropdownClose}
         onInput={onInput}
+        onClick={onClick}
       />
     );
     expect(handleSelect).toBeCalledTimes(0);
     expect(onDropdownOpen).toBeCalledTimes(0);
     expect(onDropdownClose).toBeCalledTimes(0);
     expect(onInput).toBeCalledTimes(0);
+    expect(onClick).toBeCalledTimes(0);
     const datalistInput = screen.getByRole('textbox');
     fireEvent.click(datalistInput);
     await screen.getAllByRole('button');
@@ -219,17 +291,22 @@ describe('DataListInput', () => {
     expect(onDropdownOpen).toBeCalledTimes(1);
     expect(onDropdownClose).toBeCalledTimes(0);
     expect(onInput).toBeCalledTimes(0);
+    expect(onClick).toBeCalledTimes(1);
+    expect(onClick).toBeCalledWith('');
     fireEvent.change(datalistInput, { target: { value: 'Apple' } });
     const appleItem = await screen.getByRole('button');
     expect(handleSelect).toBeCalledTimes(0);
     expect(onDropdownOpen).toBeCalledTimes(1);
     expect(onDropdownClose).toBeCalledTimes(0);
     expect(onInput).toBeCalledTimes(1);
+    expect(onInput).toBeCalledWith('Apple');
+    expect(onClick).toBeCalledTimes(1);
     fireEvent.click(appleItem);
     expect(handleSelect).toBeCalledTimes(1);
     expect(onDropdownOpen).toBeCalledTimes(1);
     expect(onDropdownClose).toBeCalledTimes(1);
     expect(onInput).toBeCalledTimes(1);
+    expect(onClick).toBeCalledTimes(1);
   });
 
   test('click outside menu closes menu', async () => {
@@ -281,6 +358,67 @@ describe('DataListInput', () => {
 
     fireEvent.click(datalistInput);
     await screen.getAllByRole('button');
+    expect(document.body).toMatchSnapshot();
+  });
+
+  test('custom value prop: renders value after setting value empty to clear input field', async () => {
+    const runtime = render(
+      <DataListInput
+        items={data}
+        placeholder={placeholder}
+        onSelect={handleSelect}
+        value={undefined}
+      />
+    );
+    const datalistInput = screen.getByRole('textbox');
+    fireEvent.click(datalistInput);
+    const items = await screen.getAllByRole('button');
+    expect(items.length).toBe(data.length);
+    fireEvent.change(datalistInput, { target: { value: 'Apple' } });
+    expect(datalistInput).toHaveAttribute('value', 'Apple');
+    expect(document.body).toMatchSnapshot();
+
+    // we don't update currentInput since the dropdown is visible
+    runtime.rerender(
+      <DataListInput
+        items={data}
+        placeholder={placeholder}
+        onSelect={handleSelect}
+        value="Peach"
+      />
+    );
+    expect(document.body).toMatchSnapshot();
+
+    const appleItem = await screen.getByRole('button');
+    fireEvent.click(appleItem);
+    expect(handleSelect).toBeCalledTimes(1);
+
+    // !!! now we have Peach since the props gave Peach, even though the user selected Apple
+    expect(datalistInput).toHaveAttribute('value', 'Peach');
+    expect(document.body).toMatchSnapshot();
+
+    // now we change to Apple
+    runtime.rerender(
+      <DataListInput
+        items={data}
+        placeholder={placeholder}
+        onSelect={handleSelect}
+        value="Apple"
+      />
+    );
+    expect(datalistInput).toHaveAttribute('value', 'Apple');
+    expect(document.body).toMatchSnapshot();
+
+    // context outside component changed, we want to clear the value
+    runtime.rerender(
+      <DataListInput
+        items={data}
+        placeholder={placeholder}
+        onSelect={handleSelect}
+        value=""
+      />
+    );
+    expect(datalistInput).toHaveAttribute('value', '');
     expect(document.body).toMatchSnapshot();
   });
 });

--- a/tests/unit/__snapshots__/DataListInput.test.js.snap
+++ b/tests/unit/__snapshots__/DataListInput.test.js.snap
@@ -1,5 +1,131 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`DataListInput custom value prop: renders value after setting value empty to clear input field 1`] = `
+<body>
+  <div>
+    <div
+      class="datalist-input"
+    >
+      <input
+        aria-label="Search"
+        class="autocomplete-input "
+        placeholder="Type something in here..."
+        type="text"
+        value="Apple"
+      />
+      <div
+        aria-label="Dropdown menu"
+        class="datalist-items default-datalist-items"
+        role="dialog"
+      >
+        <div
+          aria-label="Apple"
+          class=" datalist-active-item datalist-active-item-default"
+          role="button"
+          tabindex="0"
+        >
+          
+          <strong>
+            Apple
+          </strong>
+          
+        </div>
+      </div>
+    </div>
+  </div>
+</body>
+`;
+
+exports[`DataListInput custom value prop: renders value after setting value empty to clear input field 2`] = `
+<body>
+  <div>
+    <div
+      class="datalist-input"
+    >
+      <input
+        aria-label="Search"
+        class="autocomplete-input "
+        placeholder="Type something in here..."
+        type="text"
+        value="Apple"
+      />
+      <div
+        aria-label="Dropdown menu"
+        class="datalist-items default-datalist-items"
+        role="dialog"
+      >
+        <div
+          aria-label="Apple"
+          class=" datalist-active-item datalist-active-item-default"
+          role="button"
+          tabindex="0"
+        >
+          
+          <strong>
+            Apple
+          </strong>
+          
+        </div>
+      </div>
+    </div>
+  </div>
+</body>
+`;
+
+exports[`DataListInput custom value prop: renders value after setting value empty to clear input field 3`] = `
+<body>
+  <div>
+    <div
+      class="datalist-input"
+    >
+      <input
+        aria-label="Search"
+        class="autocomplete-input "
+        placeholder="Type something in here..."
+        type="text"
+        value="Peach"
+      />
+    </div>
+  </div>
+</body>
+`;
+
+exports[`DataListInput custom value prop: renders value after setting value empty to clear input field 4`] = `
+<body>
+  <div>
+    <div
+      class="datalist-input"
+    >
+      <input
+        aria-label="Search"
+        class="autocomplete-input "
+        placeholder="Type something in here..."
+        type="text"
+        value="Apple"
+      />
+    </div>
+  </div>
+</body>
+`;
+
+exports[`DataListInput custom value prop: renders value after setting value empty to clear input field 5`] = `
+<body>
+  <div>
+    <div
+      class="datalist-input"
+    >
+      <input
+        aria-label="Search"
+        class="autocomplete-input "
+        placeholder="Type something in here..."
+        type="text"
+        value=""
+      />
+    </div>
+  </div>
+</body>
+`;
+
 exports[`DataListInput renders the same html based on the same inputs 1`] = `
 <body>
   <div>


### PR DESCRIPTION
Motivation: [issue 23](https://github.com/andrelandgraf/react-datalist-input/issues/23)

Offer optional value prop, in case the user requires full control to change/clear the input value based on side effects

Changes:

- deprecates optional `initialValue` prop
- introduces optional `value` prop instead (default undefined)
- introduces optional `clearOnClickInput` prop (default false)
- introduces optional `onClick` lifecycle method prop (default empty function)